### PR TITLE
Flexbox drafts edit

### DIFF
--- a/app/assets/stylesheets/form_drafts/edit.scss
+++ b/app/assets/stylesheets/form_drafts/edit.scss
@@ -4,10 +4,26 @@ html {
 * {
   box-sizing: inherit; 
 }
-#top_flex_wrapper{
+
+#flex_wrapper{
   display: flex;
-  align-items: center;
-  flex-direction: column;
+  .form_column{
+    border: 1px solid black;
+    flex-direction: column;
+    flex: 3;
+    .field_row{
+      height: 6em;
+      border: 1px solid red;
+    }
+  }
+  .button_column{
+    border: 1px solid blue;
+    flex-direction: column;
+  }
+}
+
+
+/* 
   .form-config{
     flex: 1;
     margin-bottom: 2em;
@@ -44,8 +60,7 @@ html {
     .button_row.headers{
       height: 1em;
     }
-  }
-}
+  } */
   
   
   

--- a/app/assets/stylesheets/form_drafts/edit.scss
+++ b/app/assets/stylesheets/form_drafts/edit.scss
@@ -6,69 +6,52 @@ html {
 }
 
 #flex_wrapper{
-  display: flex;
-  .form_column{
-    display: flex;
-    flex-direction: column;
-    flex: 3;
+  display:flex;
+  .form_column{ /*total height 8em */
+    flex:3;
+    list-style-type: none;
     .form-config{
-      flex: 1;
+      padding: .5em;
       height:2em;
-      border: 1px solid black;
+      margin-bottom: 2em;
     }
-    .field-row{
-      height: 6em;
-      border: 1px solid red;
+    .header_row{
+      padding: .5em;
+      display:flex;
+      height:2em; /*total height 2em*/
       .field_attribute{
-        border: 1px solid blue;
+        flex:1;
+      }
+      .field_attribute_header1{
+        flex:3;
+      }
+    }
+    .fields_column{
+      display:flex;
+      flex-direction:column;
+      .field_row{
+        height:5em;
+        display: flex;
+        border-bottom:1px solid black;
+        .field_attribute_1{
+          padding: .5em;
+          flex:3;
+        }
+        .field_attribute{
+          padding: .5em;
+          flex:1;
+        }
       }
     }
   }
   .button_column{
-    border: 1px solid blue;
+    margin-top:10em; /*total em heights from above added together*/
+    display: flex;
     flex-direction: column;
-  }
-}
-
-
-/* 
-  .form-config{
-    flex: 1;
-    margin-bottom: 2em;
-  }
-}
-#flex_wrapper{
-  display: flex;
-  align-items: flex-start;
-  .column1{
-    list-style-type: none;
-    flex-direction: column;
-    flex: 3;
-    .field_row.headers{
-      height: 2em;
-    }
-    .field_row{
-      display: flex;
-      height: 6em;;
-      .field_attribute.prompt{
-        flex: 2;
-      }
-      .field_attribute{
-        flex: 1;
-      }
-    }
-  }
-  .column2{
-    flex-direction: column;
-    flex: 1;
     .button_row{
-      flex: 1;
-      height: 6em;;
+      padding: .5em;
+      border-bottom: 1px solid black;
+      height:5em;
     }
-    .button_row.headers{
-      height: 1em;
-    }
-  } */
-  
-  
-  
+  }
+}

--- a/app/assets/stylesheets/form_drafts/edit.scss
+++ b/app/assets/stylesheets/form_drafts/edit.scss
@@ -8,12 +8,20 @@ html {
 #flex_wrapper{
   display: flex;
   .form_column{
-    border: 1px solid black;
+    display: flex;
     flex-direction: column;
     flex: 3;
-    .field_row{
+    .form-config{
+      flex: 1;
+      height:2em;
+      border: 1px solid black;
+    }
+    .field-row{
       height: 6em;
       border: 1px solid red;
+      .field_attribute{
+        border: 1px solid blue;
+      }
     }
   }
   .button_column{

--- a/app/mailers/ft_forms_mailer.rb
+++ b/app/mailers/ft_forms_mailer.rb
@@ -7,7 +7,8 @@ class FtFormsMailer < ActionMailer::Base
     @form_data = parse_form_data(data)
     # TODO: configure email from form
     mail to: user.email,
-         subject: 'Meet & Greet Request Confirmation'
+         subject: 'Meet & Greet Request Confirmation',
+         reply_to: 'fieldtrip@umass.edu'
   end
 
   def send_form(form, data)

--- a/app/models/form_draft.rb
+++ b/app/models/form_draft.rb
@@ -66,6 +66,6 @@ class FormDraft < ActiveRecord::Base
   private
 
   def new_field_number
-    fields.count + 1
+    fields.last.try(:number).try(:+, 1) || 1
   end
 end

--- a/app/models/form_draft.rb
+++ b/app/models/form_draft.rb
@@ -55,7 +55,7 @@ class FormDraft < ActiveRecord::Base
   end
 
   def update_form!
-    form.update(attributes.except 'form_id', 'user_id')
+    form.update(attributes.except 'form_id', 'user_id', 'id')
     # Don't need to retain the fields, since the draft will be deleted.
     # Just switch them over to belonging to the form.
     form.fields.delete_all

--- a/app/views/form_drafts/edit.haml
+++ b/app/views/form_drafts/edit.haml
@@ -8,8 +8,8 @@
       .form-config
         = f.label :email, 'Change form email destination:'
         = f.text_field :email, required: true, size: 50
-      .field-row
-        .field_attribute
+      .header_row
+        .field_attribute_header1
           Field text
         .field_attribute
           Example response
@@ -19,14 +19,14 @@
           Required?
         .field_attribute
           Options
+      .fields_column
         = f.fields_for :fields do |g|
           - field = g.object
           - if field.new_record?
             .centered{ colspan: 5 } Add new field...
-          .field-row
-            .field_attribute
-              = g.hidden_field :number
-            .field_attribute
+          .field_row
+            = g.hidden_field :number
+            .field_attribute_1
               = g.text_area :prompt, required: !field.new_record?, size: '35x4'
             .field_attribute
               = g.text_field :placeholder if field.takes_placeholder?
@@ -45,7 +45,6 @@
           = f.submit 'Save changes and continue editing'
           = f.submit 'Preview changes'
   .button_column
-    .button_row.headers
     - @draft.fields.each do |field|
       - unless field.new_record?
         .button_row

--- a/app/views/form_drafts/edit.haml
+++ b/app/views/form_drafts/edit.haml
@@ -8,10 +8,10 @@
       .form-config
         = f.label :email, 'Change form email destination:'
         = f.text_field :email, required: true, size: 50
-      .field_row.headers
-        .field_attribute.prompt
+      .field-row
+        .field_attribute
           Field text
-        .field_attribute.prompt
+        .field_attribute
           Example response
         .field_attribute
           Response type
@@ -23,11 +23,12 @@
           - field = g.object
           - if field.new_record?
             .centered{ colspan: 5 } Add new field...
-          .field_row
-            = g.hidden_field :number
-            .field_attribute.prompt
+          .field-row
+            .field_attribute
+              = g.hidden_field :number
+            .field_attribute
               = g.text_area :prompt, required: !field.new_record?, size: '35x4'
-            .field_attribute.prompt
+            .field_attribute
               = g.text_field :placeholder if field.takes_placeholder?
             .field_attribute
               = g.select :data_type, Field::DATA_TYPES,

--- a/app/views/form_drafts/edit.haml
+++ b/app/views/form_drafts/edit.haml
@@ -1,61 +1,61 @@
 %h1.title Editing #{@draft.form.name}
-#top_flex_wrapper
-  = form_for @draft do |f|
-  .form-config
-    = f.label :name, 'Change form title:'
-    = f.text_field :name, required: true, size: 50
-  .form-config
-    = f.label :email, 'Change form email destination:'
-    = f.text_field :email, required: true, size: 50
-#flex_wrapper
-  .column1
-    .field_row.headers
-      .field_attribute.prompt
-        Field text
-      .field_attribute.prompt
-        Example response
-      .field_attribute
-        Response type
-      .field_attribute
-        Required?
-      .field_attribute
-        Options
-    = f.fields_for :fields do |g|
-      - field = g.object
-      - if field.new_record?
-        .centered{ colspan: 5 } Add new field...
-      .field_row
-        = g.hidden_field :number
+= form_for @draft do |f|
+  #top_flex_wrapper
+    .form-config
+      = f.label :name, 'Change form title:'
+      = f.text_field :name, required: true, size: 50
+    .form-config
+      = f.label :email, 'Change form email destination:'
+      = f.text_field :email, required: true, size: 50
+  #flex_wrapper
+    .column1
+      .field_row.headers
         .field_attribute.prompt
-          = g.text_area :prompt, required: !field.new_record?, size: '35x4'
+          Field text
         .field_attribute.prompt
-          = g.text_field :placeholder if field.takes_placeholder?
+          Example response
         .field_attribute
-          = g.select :data_type, Field::DATA_TYPES,
-            include_blank: 'Select a data type...',
-            required: !field.new_record?
+          Response type
         .field_attribute
-          = g.check_box :required
+          Required?
         .field_attribute
-          - if field.data_type == 'options'
-            - field.options.each do |option|
-              %li= option
-            %li= link_to 'Configure options', edit_field_path(field)
-    .actions
-      = f.submit 'Save changes and continue editing'
-      = f.submit 'Preview changes'
-  .column2
-    .button_row.headers
-    - @draft.fields.each do |field|
-      - unless field.new_record?
-        .button_row
-          - unless @draft.fields.index(field).zero?
-            = button_to 'Move up',
-              move_field_form_draft_path(@draft, number: field.number,
-                                         direction: :up)
-          - unless field == @draft.fields.not_new.last
-            = button_to 'Move down',
-              move_field_form_draft_path(@draft, number: field.number,
-                                         direction: :down)
-          = button_to 'Remove field',
-            remove_field_form_draft_path(@draft, number: field.number)
+          Options
+      = f.fields_for :fields do |g|
+        - field = g.object
+        - if field.new_record?
+          .centered{ colspan: 5 } Add new field...
+        .field_row
+          = g.hidden_field :number
+          .field_attribute.prompt
+            = g.text_area :prompt, required: !field.new_record?, size: '35x4'
+          .field_attribute.prompt
+            = g.text_field :placeholder if field.takes_placeholder?
+          .field_attribute
+            = g.select :data_type, Field::DATA_TYPES,
+              include_blank: 'Select a data type...',
+              required: !field.new_record?
+          .field_attribute
+            = g.check_box :required
+          .field_attribute
+            - if field.data_type == 'options'
+              - field.options.each do |option|
+                %li= option
+              %li= link_to 'Configure options', edit_field_path(field)
+      .actions
+        = f.submit 'Save changes and continue editing'
+        = f.submit 'Preview changes'
+    .column2
+      .button_row.headers
+      - @draft.fields.each do |field|
+        - unless field.new_record?
+          .button_row
+            - unless @draft.fields.index(field).zero?
+              = button_to 'Move up',
+                move_field_form_draft_path(@draft, number: field.number,
+                                           direction: :up)
+            - unless field == @draft.fields.not_new.last
+              = button_to 'Move down',
+                move_field_form_draft_path(@draft, number: field.number,
+                                           direction: :down)
+            = button_to 'Remove field',
+              remove_field_form_draft_path(@draft, number: field.number)

--- a/app/views/form_drafts/edit.haml
+++ b/app/views/form_drafts/edit.haml
@@ -1,14 +1,13 @@
 %h1.title Editing #{@draft.form.name}
-= form_for @draft do |f|
-  #top_flex_wrapper
-    .form-config
-      = f.label :name, 'Change form title:'
-      = f.text_field :name, required: true, size: 50
-    .form-config
-      = f.label :email, 'Change form email destination:'
-      = f.text_field :email, required: true, size: 50
-  #flex_wrapper
-    .column1
+#flex_wrapper
+  .form_column
+    = form_for @draft do |f|
+      .form-config
+        = f.label :name, 'Change form title:'
+        = f.text_field :name, required: true, size: 50
+      .form-config
+        = f.label :email, 'Change form email destination:'
+        = f.text_field :email, required: true, size: 50
       .field_row.headers
         .field_attribute.prompt
           Field text
@@ -20,42 +19,42 @@
           Required?
         .field_attribute
           Options
-      = f.fields_for :fields do |g|
-        - field = g.object
-        - if field.new_record?
-          .centered{ colspan: 5 } Add new field...
-        .field_row
-          = g.hidden_field :number
-          .field_attribute.prompt
-            = g.text_area :prompt, required: !field.new_record?, size: '35x4'
-          .field_attribute.prompt
-            = g.text_field :placeholder if field.takes_placeholder?
-          .field_attribute
-            = g.select :data_type, Field::DATA_TYPES,
-              include_blank: 'Select a data type...',
-              required: !field.new_record?
-          .field_attribute
-            = g.check_box :required
-          .field_attribute
-            - if field.data_type == 'options'
-              - field.options.each do |option|
-                %li= option
-              %li= link_to 'Configure options', edit_field_path(field)
-      .actions
-        = f.submit 'Save changes and continue editing'
-        = f.submit 'Preview changes'
-    .column2
-      .button_row.headers
-      - @draft.fields.each do |field|
-        - unless field.new_record?
-          .button_row
-            - unless @draft.fields.index(field).zero?
-              = button_to 'Move up',
-                move_field_form_draft_path(@draft, number: field.number,
-                                           direction: :up)
-            - unless field == @draft.fields.not_new.last
-              = button_to 'Move down',
-                move_field_form_draft_path(@draft, number: field.number,
-                                           direction: :down)
-            = button_to 'Remove field',
-              remove_field_form_draft_path(@draft, number: field.number)
+        = f.fields_for :fields do |g|
+          - field = g.object
+          - if field.new_record?
+            .centered{ colspan: 5 } Add new field...
+          .field_row
+            = g.hidden_field :number
+            .field_attribute.prompt
+              = g.text_area :prompt, required: !field.new_record?, size: '35x4'
+            .field_attribute.prompt
+              = g.text_field :placeholder if field.takes_placeholder?
+            .field_attribute
+              = g.select :data_type, Field::DATA_TYPES,
+                include_blank: 'Select a data type...',
+                required: !field.new_record?
+            .field_attribute
+              = g.check_box :required
+            .field_attribute
+              - if field.data_type == 'options'
+                - field.options.each do |option|
+                  %li= option
+                %li= link_to 'Configure options', edit_field_path(field)
+        .actions
+          = f.submit 'Save changes and continue editing'
+          = f.submit 'Preview changes'
+  .button_column
+    .button_row.headers
+    - @draft.fields.each do |field|
+      - unless field.new_record?
+        .button_row
+          - unless @draft.fields.index(field).zero?
+            = button_to 'Move up',
+              move_field_form_draft_path(@draft, number: field.number,
+                                         direction: :up)
+          - unless field == @draft.fields.not_new.last
+            = button_to 'Move down',
+              move_field_form_draft_path(@draft, number: field.number,
+                                         direction: :down)
+          = button_to 'Remove field',
+            remove_field_form_draft_path(@draft, number: field.number)

--- a/app/views/ft_forms_mailer/send_confirmation.text.erb
+++ b/app/views/ft_forms_mailer/send_confirmation.text.erb
@@ -5,6 +5,8 @@ You will be contacted once your request has been processed, typically within 2-5
 If you have requested transportation that is within 3 business days please call our office at 
 (413) 545-2498 to confirm availability.
 
+Please do not reply to this email; we can be reached at fieldtrip@umass.edu.
+
 Below is the request that we received:
 
 <% @form_data.each do |prompt, response| %>

--- a/spec/mailers/ft_forms_mailer_spec.rb
+++ b/spec/mailers/ft_forms_mailer_spec.rb
@@ -17,6 +17,9 @@ describe FtFormsMailer do
     it 'sends to the email of the user' do
       expect(output.to).to eql Array(@user.email)
     end
+    it 'has a reply-to of fieldtrip@umass.edu' do
+      expect(output.reply_to).to eql Array('fieldtrip@umass.edu')
+    end
     it 'has a subject of Meet & Greet Request Confirmation' do
       expect(output.subject).to eql 'Meet & Greet Request Confirmation'
     end
@@ -40,6 +43,12 @@ describe FtFormsMailer do
     end
     it 'sends to the email of the form' do
       expect(output.to).to eql Array(@form.email)
+    end
+    it 'sends to multiple emails of the form if separated by comma' do
+      email_1 = 'person@test.host'
+      email_2 = 'people@test.host'
+      @form.update email: [email_1, email_2].join(', ')
+      expect(output.to).to eql [email_1, email_2]
     end
     it 'has a subject of New Meet & Greet Request' do
       expect(output.subject).to eql 'New Meet & Greet Request'

--- a/spec/models/field_spec.rb
+++ b/spec/models/field_spec.rb
@@ -36,27 +36,21 @@ describe Field do
       end
     end
   end
-  context 'validation methods' do
-    describe 'belongs_to_form_or_form_draft?' do
-      before :each do
-        @form = create :form
-        @draft = create :form_draft
+
+  describe 'takes_placeholder?' do
+    before :each do
+      @draft = create :form_draft
+    end
+    it 'returns true for date, date/time, long-text, text or time' do
+      %w(date date/time long-text text time).each do |data_type|
+        field = create :field, form_draft: @draft, data_type: data_type
+        expect(field.takes_placeholder?).to eql true
       end
-      it 'fails if a field does not belong to a form or form draft' do
-        expect { create :field }
-          .to raise_error ActiveRecord::RecordInvalid
-      end
-      it 'fails if a field belongs to both a form and a form draft' do
-        expect { create :field, form: @form, form_draft: @draft }
-          .to raise_error ActiveRecord::RecordInvalid
-      end
-      it 'passes if a field belongs to a form but not a form draft' do
-        expect { create :field, form: @form }
-          .not_to raise_error
-      end
-      it 'passes if a field belongs to a form draft but not a form' do
-        expect { create :field, form_draft: @draft }
-          .not_to raise_error
+    end
+    it 'returns false for explanation, heading, number, options, or yes/no' do
+      %w(explanation heading number options yes/no).each do |data_type|
+        field = create :field, form_draft: @draft, data_type: data_type
+        expect(field.takes_placeholder?).to eql false
       end
     end
   end
@@ -80,6 +74,31 @@ describe Field do
     it 'returns field followed by number' do
       result = ['field', @field.number].join '_'
       expect(@field.unique_name).to eql result
+    end
+  end
+
+  context 'validation methods' do
+    describe 'belongs_to_form_or_form_draft?' do
+      before :each do
+        @form = create :form
+        @draft = create :form_draft
+      end
+      it 'fails if a field does not belong to a form or form draft' do
+        expect { create :field }
+          .to raise_error ActiveRecord::RecordInvalid
+      end
+      it 'fails if a field belongs to both a form and a form draft' do
+        expect { create :field, form: @form, form_draft: @draft }
+          .to raise_error ActiveRecord::RecordInvalid
+      end
+      it 'passes if a field belongs to a form but not a form draft' do
+        expect { create :field, form: @form }
+          .not_to raise_error
+      end
+      it 'passes if a field belongs to a form draft but not a form' do
+        expect { create :field, form_draft: @draft }
+          .not_to raise_error
+      end
     end
   end
 end

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -64,10 +64,10 @@ describe Form do
     let :call do
       @form.draft_belonging_to? @user
     end
-    it 'returns false if a draft exists for the user in question' do
+    it 'returns false if a draft does not exist for the user in question' do
       expect(call).to eql false
     end
-    it 'returns true if a draft does not exist for the user in question' do
+    it 'returns true if a draft exists for the user in question' do
       create :form_draft, user: @user, form: @form
       expect(call).to eql true
     end

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -64,10 +64,10 @@ describe Form do
     let :call do
       @form.draft_belonging_to? @user
     end
-    it 'returns false if a draft does not exist for the user in question' do
+    it 'returns false if draft does not exist for the user in question' do
       expect(call).to eql false
     end
-    it 'returns true if a draft exists for the user in question' do
+    it 'returns true if draft exists for the user in question' do
       create :form_draft, user: @user, form: @form
       expect(call).to eql true
     end

--- a/spec/views/form_drafts/edit_spec.rb
+++ b/spec/views/form_drafts/edit_spec.rb
@@ -22,22 +22,29 @@ describe 'form_drafts/edit.haml' do
       with_text_field 'form_draft[email]'
     end
   end
-  # I want these to be lined up, stop yelling at me
-  # rubocop:disable Style/SingleSpaceBeforeFirstArg
   it 'has inputs for each field' do
     render
-    expect(rendered).to have_tag 'tr' do
+    expect(rendered).to have_tag 'input' do
       (0...@draft.fields.count).each do |index|
         base_tag_name = "form_draft[fields_attributes][#{index}]"
         with_hidden_field "#{base_tag_name}[number]"
-        with_text_area    "#{base_tag_name}[prompt]"
-        with_text_field   "#{base_tag_name}[placeholder]"
-        with_select       "#{base_tag_name}[data_type]"
-        with_checkbox     "#{base_tag_name}[required]"
+        with_text_field "#{base_tag_name}[placeholder]"
+        with_checkbox "#{base_tag_name}[required]"
+      end
+    end
+    expect(rendered).to have_tag 'textarea' do
+      (0...@draft.fields.count).each do |index|
+        base_tag_name = "form_draft[fields_attributes][#{index}]"
+        with_text_area "#{base_tag_name}[prompt]"
+      end
+    end
+    expect(rendered).to have_tag 'select' do
+      (0...@draft.fields.count).each do |index|
+        base_tag_name = "form_draft[fields_attributes][#{index}]"
+        with_select "#{base_tag_name}[data_type]"
       end
     end
   end
-  # rubocop:enable Style/SingleSpaceBeforeFirstArg
   context 'input data type is options' do
     before :each do
       @field.update data_type: 'options', options: %w(car van)

--- a/spec/views/form_drafts/edit_spec.rb
+++ b/spec/views/form_drafts/edit_spec.rb
@@ -27,11 +27,14 @@ describe 'form_drafts/edit.haml' do
   it 'has inputs for each field' do
     render
     expect(rendered).to have_tag 'tr' do
-      with_hidden_field 'form_draft[fields_attributes][0][number]'
-      with_text_area    'form_draft[fields_attributes][0][prompt]'
-      with_text_field   'form_draft[fields_attributes][0][placeholder]'
-      with_select       'form_draft[fields_attributes][0][data_type]'
-      with_checkbox     'form_draft[fields_attributes][0][required]'
+      (0...@draft.fields.count).each do |index|
+        base_tag_name = "form_draft[fields_attributes][#{index}]"
+        with_hidden_field "#{base_tag_name}[number]"
+        with_text_area    "#{base_tag_name}[prompt]"
+        with_text_field   "#{base_tag_name}[placeholder]"
+        with_select       "#{base_tag_name}[data_type]"
+        with_checkbox     "#{base_tag_name}[required]"
+      end
     end
   end
   # rubocop:enable Style/SingleSpaceBeforeFirstArg

--- a/spec/views/ft_forms_mailer/send_confirmation_text_spec.rb
+++ b/spec/views/ft_forms_mailer/send_confirmation_text_spec.rb
@@ -9,6 +9,10 @@ describe 'ft_forms_mailer/send_confirmation.text.erb' do
     render
     expect(rendered).to include 'UMass Transit Meet & Greet Service'
   end
+  it 'includes a note about not replying to transit-it' do
+    render
+    expect(rendered).to include 'Please do not reply to this email'
+  end
   it 'includes the form data of the request' do
     render
     expect(rendered).to include 'question1: answer1',


### PR DESCRIPTION
Fixed edit forms page so that instead of using tables, it uses flexbox in CSS to fix the "form within a form" thing that we had going on. Everything seems to work. @dfaulken, I had to remove your rubocop comment message in the spec file. Things don't line up like you want any more but rubocop doesn't complain and that's all I wanted. It will be an easy fix for you if you really care, but I changed the spec file around and the lineup we had previously doesn't matter as much in my opinion.

closes #27 
