### PR TITLE
Datetimepicker initialize blank

### DIFF
--- a/app/assets/javascripts/vendor_invocations.js.coffee
+++ b/app/assets/javascripts/vendor_invocations.js.coffee
@@ -8,6 +8,7 @@ $(document).ready ->
   $('.datetimepicker').datetimepicker
     format: 'l, F j, Y g:i a' 
     step:       15
+    defaultDate: null
 
   $('.timepicker').timepicker
     timeFormat: 'g:i a'

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -19,7 +19,6 @@ module ApplicationHelper
     responses = []
     data.each do |k, v|
       data_type, number = k.split '_'
-      binding.pry
       case data_type
       when 'field'
         responses[number.to_i] = v

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -19,6 +19,7 @@ module ApplicationHelper
     responses = []
     data.each do |k, v|
       data_type, number = k.split '_'
+      binding.pry
       case data_type
       when 'field'
         responses[number.to_i] = v


### PR DESCRIPTION
Previously when submitting a M&G request and leaving the optional "return trip" date and time value blank, the javascript would default to "right now" and show the date of the return trip as the date and time the form was submitted. The default value of datepicker is now null, therefore the "this field is required" validation will still work, and for a field that is not required, it auto-fills with nothing. 
Closes #42 