### PR TITLE
Update datetimepicker, closes #43

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,6 @@ gem 'factory_girl_rails'
 gem 'haml'
 gem 'haml-lint'
 gem 'haml-rails'
-gem 'jquery-datetimepicker-rails'
 gem 'jquery-rails'
 gem 'jquery-timepicker-rails'
 gem 'jquery-ui-rails'
@@ -16,6 +15,10 @@ gem 'rubocop'
 gem 'sass-rails'
 gem 'snappconfig'
 gem 'uglifier'
+
+source 'https://rails-assets.org' do
+  gem 'rails-assets-datetimepicker'
+end
 
 group :production do
   gem 'exception_notification'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,6 @@
 GEM
   remote: https://rubygems.org/
+  remote: https://rails-assets.org/
   specs:
     actionmailer (4.2.3)
       actionpack (= 4.2.3)
@@ -108,7 +109,6 @@ GEM
       nokogiri (~> 1.6.0)
       ruby_parser (~> 3.5)
     i18n (0.7.0)
-    jquery-datetimepicker-rails (2.4.1.0)
     jquery-rails (4.0.4)
       rails-dom-testing (~> 1.0)
       railties (>= 4.2.0)
@@ -159,6 +159,9 @@ GEM
       bundler (>= 1.3.0, < 2.0)
       railties (= 4.2.3)
       sprockets-rails
+    rails-assets-datetimepicker (2.4.5)
+      rails-assets-jquery (>= 1.7.2)
+    rails-assets-jquery (2.1.4)
     rails-deprecated_sanitizer (1.0.3)
       activesupport (>= 4.2.0.alpha)
     rails-dom-testing (1.0.6)
@@ -263,7 +266,6 @@ DEPENDENCIES
   haml
   haml-lint
   haml-rails
-  jquery-datetimepicker-rails
   jquery-rails
   jquery-timepicker-rails
   jquery-ui-rails
@@ -271,6 +273,7 @@ DEPENDENCIES
   mysql
   pry-byebug
   rails
+  rails-assets-datetimepicker!
   redcarpet
   rspec-html-matchers
   rspec-rails
@@ -283,4 +286,4 @@ DEPENDENCIES
   uglifier
 
 BUNDLED WITH
-   1.10.5
+   1.10.6

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -13,6 +13,6 @@
 //= require jquery
 //= require jquery_ujs
 //= require jquery-ui
-//= require jquery.datetimepicker
+//= require datetimepicker
 //= require jquery.timepicker
 //= require_tree .

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -12,7 +12,7 @@
  *
  *= require jquery-ui
  *= require jquery.timepicker
- *= require jquery.datetimepicker
+ *= require datetimepicker
  *= require_tree .
  *= require_self
  */


### PR DESCRIPTION
Old maintainer of the asset gem isn't maintaining it anymore.  They
suggested using rails-assets (rails-assets.org) for asset-only "gems"