### PR TITLE
Adding a configurable reply_to attribute to forms.

### DIFF
--- a/app/controllers/forms_controller.rb
+++ b/app/controllers/forms_controller.rb
@@ -25,6 +25,7 @@ class FormsController < ApplicationController
     user = @current_user || create_user
     data = params.require :responses
     FtFormsMailer.send_form(@form, data).deliver_now
+    binding.pry
     FtFormsMailer.send_confirmation(user, data, @form.reply_to).deliver_now
     redirect_to thank_you_form_url
   end

--- a/app/controllers/forms_controller.rb
+++ b/app/controllers/forms_controller.rb
@@ -25,8 +25,7 @@ class FormsController < ApplicationController
     user = @current_user || create_user
     data = params.require :responses
     FtFormsMailer.send_form(@form, data).deliver_now
-    binding.pry
-    FtFormsMailer.send_confirmation(user, data, @form.reply_to).deliver_now
+    FtFormsMailer.send_confirmation(user, data, params[:reply_to]).deliver_now
     redirect_to thank_you_form_url
   end
 

--- a/app/controllers/forms_controller.rb
+++ b/app/controllers/forms_controller.rb
@@ -25,7 +25,7 @@ class FormsController < ApplicationController
     user = @current_user || create_user
     data = params.require :responses
     FtFormsMailer.send_form(@form, data).deliver_now
-    FtFormsMailer.send_confirmation(user, data).deliver_now
+    FtFormsMailer.send_confirmation(user, data, @form.reply_to).deliver_now
     redirect_to thank_you_form_url
   end
 

--- a/app/mailers/ft_forms_mailer.rb
+++ b/app/mailers/ft_forms_mailer.rb
@@ -2,13 +2,15 @@ include ApplicationHelper
 
 class FtFormsMailer < ActionMailer::Base
   default from: 'transit-it@admin.umass.edu'
+  default reply_to: 'fieldtrip@umass.edu'
 
   def send_confirmation(user, data)
     @form_data = parse_form_data(data)
     # TODO: configure email from form
+    binding.pry
     mail to: user.email,
          subject: 'Meet & Greet Request Confirmation',
-         reply_to: 'fieldtrip@umass.edu'
+         reply_to: @form_data.reply_to
   end
 
   def send_form(form, data)

--- a/app/mailers/ft_forms_mailer.rb
+++ b/app/mailers/ft_forms_mailer.rb
@@ -4,13 +4,12 @@ class FtFormsMailer < ActionMailer::Base
   default from: 'transit-it@admin.umass.edu'
   default reply_to: 'fieldtrip@umass.edu'
 
-  def send_confirmation(user, data)
+  def send_confirmation(user, data, reply_to)
     @form_data = parse_form_data(data)
     # TODO: configure email from form
-    binding.pry
     mail to: user.email,
          subject: 'Meet & Greet Request Confirmation',
-         reply_to: @form_data.reply_to
+         reply_to: reply_to
   end
 
   def send_form(form, data)

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -6,8 +6,6 @@ class Form < ActiveRecord::Base
   accepts_nested_attributes_for :fields
 
   validates :name, presence: true, uniqueness: true
-  validates :reply_to, presence: true
-
   default_scope { order :name }
 
   def create_draft(user)

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -6,6 +6,7 @@ class Form < ActiveRecord::Base
   accepts_nested_attributes_for :fields
 
   validates :name, presence: true, uniqueness: true
+  validates :reply_to, presence: true
 
   default_scope { order :name }
 

--- a/app/models/form_draft.rb
+++ b/app/models/form_draft.rb
@@ -3,7 +3,7 @@ class FormDraft < ActiveRecord::Base
   belongs_to :user
   has_many :fields, dependent: :destroy
   accepts_nested_attributes_for :fields
-  validates :form, :name, :reply_to, presence: true
+  validates :form, :name, presence: true
   # One user can only have one draft per form
   validates :form, uniqueness: { scope: :user_id }
 

--- a/app/models/form_draft.rb
+++ b/app/models/form_draft.rb
@@ -3,7 +3,7 @@ class FormDraft < ActiveRecord::Base
   belongs_to :user
   has_many :fields, dependent: :destroy
   accepts_nested_attributes_for :fields
-  validates :form, :name, presence: true
+  validates :form, :name, :reply_to, presence: true
   # One user can only have one draft per form
   validates :form, uniqueness: { scope: :user_id }
 

--- a/app/views/form_drafts/edit.haml
+++ b/app/views/form_drafts/edit.haml
@@ -8,6 +8,9 @@
       .form-config
         = f.label :email, 'Change form email destination:'
         = f.text_field :email, required: true, size: 50
+      .form_config
+        = f.label :reply_to, 'Set address that confirmation email will tell people to replyto'
+        = f.text_field :reply_to, required: true, size:50
       .header_row
         .field_attribute_header1
           Field text

--- a/app/views/form_drafts/edit.haml
+++ b/app/views/form_drafts/edit.haml
@@ -9,8 +9,9 @@
         = f.label :email, 'Change form email destination:'
         = f.text_field :email, required: true, size: 50
       .form_config
-        = f.label :reply_to, 'Set address that confirmation email will tell people to replyto'
-        = f.text_field :reply_to, required: true, size:50
+        = f.label :reply_to,
+          'Set address that confirmation email will tell people to replyto'
+        = f.text_field :reply_to, required: true, size: 50
       .header_row
         .field_attribute_header1
           Field text

--- a/app/views/forms/show.haml
+++ b/app/views/forms/show.haml
@@ -2,12 +2,12 @@
 / please reflect them at form_drafts/show.
 .form
   %h1.title= @form.name
-  = hidden_field @form, @form.reply_to
   %strong
     Fields marked with an asterisk (
     %span.ast *
     ) are required.
   = form_tag action: :submit, id: @form.id do
+    = hidden_field_tag 'reply_to', @form.reply_to
     = fields_for :user do |u|
       .field
         .heading Please complete the following personal information.

--- a/app/views/forms/show.haml
+++ b/app/views/forms/show.haml
@@ -2,7 +2,7 @@
 / please reflect them at form_drafts/show.
 .form
   %h1.title= @form.name
-  = hidden_field :@form, @form.reply_to
+  = hidden_field :form, @form.reply_to
   %strong
     Fields marked with an asterisk (
     %span.ast *

--- a/app/views/forms/show.haml
+++ b/app/views/forms/show.haml
@@ -2,6 +2,7 @@
 / please reflect them at form_drafts/show.
 .form
   %h1.title= @form.name
+  = hidden_field :@form, @form.reply_to
   %strong
     Fields marked with an asterisk (
     %span.ast *

--- a/app/views/forms/show.haml
+++ b/app/views/forms/show.haml
@@ -7,7 +7,7 @@
     %span.ast *
     ) are required.
   = form_tag action: :submit, id: @form.id do
-    = hidden_field_tag 'reply_to', @form.reply_to
+    = hidden_field_tag :reply_to, @form.reply_to
     = fields_for :user do |u|
       .field
         .heading Please complete the following personal information.

--- a/app/views/forms/show.haml
+++ b/app/views/forms/show.haml
@@ -2,7 +2,7 @@
 / please reflect them at form_drafts/show.
 .form
   %h1.title= @form.name
-  = hidden_field :form, @form.reply_to
+  = hidden_field @form, @form.reply_to
   %strong
     Fields marked with an asterisk (
     %span.ast *

--- a/db/migrate/20151204164825_add_replyto_to_form_drafts.rb
+++ b/db/migrate/20151204164825_add_replyto_to_form_drafts.rb
@@ -1,0 +1,5 @@
+class AddReplytoToFormDrafts < ActiveRecord::Migration
+  def change
+    add_column :form_drafts, :reply_to, :string
+  end
+end

--- a/db/migrate/20151204165537_add_replyto_to_forms.rb
+++ b/db/migrate/20151204165537_add_replyto_to_forms.rb
@@ -1,0 +1,5 @@
+class AddReplytoToForms < ActiveRecord::Migration
+  def change
+    add_column :forms, :reply_to, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150802005823) do
+ActiveRecord::Schema.define(version: 20151204165537) do
 
   create_table "fields", force: :cascade do |t|
     t.integer  "number",        limit: 4
@@ -34,6 +34,7 @@ ActiveRecord::Schema.define(version: 20150802005823) do
     t.datetime "updated_at"
     t.integer  "user_id",    limit: 4
     t.string   "email",      limit: 255
+    t.string   "reply_to",   limit: 255
   end
 
   create_table "forms", force: :cascade do |t|
@@ -42,6 +43,7 @@ ActiveRecord::Schema.define(version: 20150802005823) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string   "email",      limit: 255
+    t.string   "reply_to",   limit: 255
   end
 
   create_table "users", force: :cascade do |t|

--- a/spec/controllers/forms_controller_spec.rb
+++ b/spec/controllers/forms_controller_spec.rb
@@ -106,7 +106,8 @@ describe FormsController do
       }
     end
     let :submit do
-      post :submit, id: @form.id, responses: @responses, user: @user
+      post :submit, id: @form.id, responses: @responses,
+                    user: @user, reply_to: @form.reply_to
     end
     context 'whether staff or not' do
       [:not_staff, :staff].each do |user_type|
@@ -129,7 +130,7 @@ describe FormsController do
                                                      :send_confirmation)
             expect(FtFormsMailer)
               .to receive(:send_confirmation)
-              .with(@current_user, @responses)
+              .with(@current_user, @responses, @form.reply_to)
               .and_return mail
             expect(mail).to receive(:deliver_now).and_return true
             submit

--- a/spec/mailers/ft_forms_mailer_spec.rb
+++ b/spec/mailers/ft_forms_mailer_spec.rb
@@ -6,13 +6,14 @@ describe FtFormsMailer do
       @user = create :user
       @response = 'A response'
       @prompt = 'A prompt'
+      @reply_to = 'fieldtrip@umass.edu'
       @form_data = {
         'field_2'  => @response,
         'prompt_2' => @prompt
       }
     end
     let :output do
-      FtFormsMailer.send_confirmation @user, @form_data
+      FtFormsMailer.send_confirmation @user, @form_data, @reply_to
     end
     it 'sends to the email of the user' do
       expect(output.to).to eql Array(@user.email)


### PR DESCRIPTION
This will enable a user creating the form to change the default reply_to address to something they want (perhaps themselves, perhaps their boss, etc).  

All I really did was add a column to the Form and FormDraft tables; a string called reply_to.  In form_drafts/edit, the person editing the form can (and must!) specify a reply_to address.

This address is then passed along throughout the process of becoming a true Form.  It is then passed to the send_confirmation mailer method as a (newly defined) parameter from the Form controller.

Closes #39.