### PR TITLE
Changed confirmation email from "required" to "not required"

### DIFF
--- a/app/views/form_drafts/edit.haml
+++ b/app/views/form_drafts/edit.haml
@@ -11,7 +11,7 @@
       .form_config
         = f.label :reply_to,
           'Set address that confirmation email will tell people to replyto'
-        = f.text_field :reply_to, required: false, size: 50
+        = f.text_field :reply_to, size: 50
       .header_row
         .field_attribute_header1
           Field text

--- a/app/views/form_drafts/edit.haml
+++ b/app/views/form_drafts/edit.haml
@@ -11,7 +11,7 @@
       .form_config
         = f.label :reply_to,
           'Set address that confirmation email will tell people to replyto'
-        = f.text_field :reply_to, required: true, size: 50
+        = f.text_field :reply_to, required: false, size: 50
       .header_row
         .field_attribute_header1
           Field text


### PR DESCRIPTION
An offshoot that would close #39 were it reopened - when creating the configurable reply-to address, we set the field for the custom address to be required.  It doesn't need to be, so this PR changes that.