### PR TITLE
changed wording, changed styling

### DIFF
--- a/app/views/form_drafts/edit.haml
+++ b/app/views/form_drafts/edit.haml
@@ -8,9 +8,8 @@
       .form-config
         = f.label :email, 'Change form email destination:'
         = f.text_field :email, required: true, size: 50
-      .form_config
-        = f.label :reply_to,
-          'Set address that confirmation email will tell people to replyto'
+      .form-config
+        = f.label :reply_to, 'Set reply-to address'
         = f.text_field :reply_to, size: 50
       .header_row
         .field_attribute_header1


### PR DESCRIPTION
Observe the original:
![screen shot 2016-04-13 at 2 24 13 pm](https://cloud.githubusercontent.com/assets/9645316/14504585/70a508ac-0183-11e6-8a1c-97b9da8b555d.png)

And my edit:
![screen shot 2016-04-13 at 2 23 50 pm](https://cloud.githubusercontent.com/assets/9645316/14504592/74422544-0183-11e6-9f54-77f4353820bc.png)

Just noticed it as I was going in there seeing how the reply-to thing works. Thought I'd make it nicer.