### PR TITLE
Personal info

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,7 +5,6 @@ class ApplicationController < ActionController::Base
   before_action :set_current_user
   before_action :redirect_unauthenticated
   before_action :access_control
-  before_action :set_shibboleth_attributes
   layout 'application'
 
   private
@@ -51,14 +50,6 @@ class ApplicationController < ActionController::Base
 
   def set_spire
     session[:spire] = request.env['fcIdNumber'] if request.env.key? 'fcIdNumber'
-  end
-
-  def set_shibboleth_attributes
-    [:mail, :first_name, :last_name].each do |attribute|
-      if request.env.key? attribute.to_s # request.env keys are strings
-        session[attribute] = request.env[attribute.to_s]
-      end
-    end
   end
 
   # '... and return' is correct here, disable rubocop warning

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -52,10 +52,10 @@ class ApplicationController < ActionController::Base
   def set_spire
     session[:spire] = request.env['fcIdNumber'] if request.env.key? 'fcIdNumber'
   end
-  
+
   def set_shibboleth_attributes
     [:mail, :first_name, :last_name].each do |attribute|
-      if request.env.key? attribute.to_s #request.env keys are strings
+      if request.env.key? attribute.to_s # request.env keys are strings
         session[attribute] = request.env[attribute.to_s]
       end
     end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,6 +5,7 @@ class ApplicationController < ActionController::Base
   before_action :set_current_user
   before_action :redirect_unauthenticated
   before_action :access_control
+  before_action :shibboleth_attributes
   layout 'application'
 
   private
@@ -46,6 +47,15 @@ class ApplicationController < ActionController::Base
       elsif session.key? :spire
         User.find_by spire: session[:spire]
       end
+  end
+
+  def shibboleth_attributes
+    mail = request.env['mail']
+    first_name = request.env['givenName']
+    last_name = request.env['surName']
+    @placeholder = User.new(email: mail,
+                            first_name: first_name,
+                            last_name: last_name)
   end
 
   def set_spire

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,7 +5,7 @@ class ApplicationController < ActionController::Base
   before_action :set_current_user
   before_action :redirect_unauthenticated
   before_action :access_control
-  before_action :shibboleth_attributes
+  before_action :set_shibboleth_attributes
   layout 'application'
 
   private
@@ -49,17 +49,16 @@ class ApplicationController < ActionController::Base
       end
   end
 
-  def shibboleth_attributes
-    mail = request.env['mail']
-    first_name = request.env['givenName']
-    last_name = request.env['surName']
-    @placeholder = User.new(email: mail,
-                            first_name: first_name,
-                            last_name: last_name)
-  end
-
   def set_spire
     session[:spire] = request.env['fcIdNumber'] if request.env.key? 'fcIdNumber'
+  end
+  
+  def set_shibboleth_attributes
+    [:mail, :first_name, :last_name].each do |attribute|
+      if request.env.key? attribute.to_s #request.env keys are strings
+        session[attribute] = request.env[attribute.to_s]
+      end
+    end
   end
 
   # '... and return' is correct here, disable rubocop warning

--- a/app/controllers/forms_controller.rb
+++ b/app/controllers/forms_controller.rb
@@ -7,7 +7,7 @@ class FormsController < ApplicationController
   # Since these actions are used to edit forms, maintain the form in session.
   before_action :find_form, only: [:show, :submit, :thank_you, :update]
   before_action :placeholder_from_shibboleth_attributes, only: [:show,
-    :meet_and_greet]
+                                                                :meet_and_greet]
 
   def index
     @forms = Form.includes :drafts

--- a/app/controllers/forms_controller.rb
+++ b/app/controllers/forms_controller.rb
@@ -6,6 +6,7 @@ class FormsController < ApplicationController
                                              :thank_you]
   # Since these actions are used to edit forms, maintain the form in session.
   before_action :find_form, only: [:show, :submit, :thank_you, :update]
+  before_action :shibboleth_attributes
 
   def index
     @forms = Form.includes :drafts
@@ -22,6 +23,12 @@ class FormsController < ApplicationController
   end
 
   def submit
+    if @current_user.present?
+      @current_user.update_attributes(
+        params.require(:user)
+        .permit(:first_name, :last_name, :email)
+      )
+    end
     user = @current_user || create_user
     data = params.require :responses
     FtFormsMailer.send_form(@form, data).deliver_now

--- a/app/controllers/forms_controller.rb
+++ b/app/controllers/forms_controller.rb
@@ -6,7 +6,7 @@ class FormsController < ApplicationController
                                              :thank_you]
   # Since these actions are used to edit forms, maintain the form in session.
   before_action :find_form, only: [:show, :submit, :thank_you, :update]
-  before_action :shibboleth_attributes
+  before_action :placeholder, only: [:show, :meet_and_greet]
 
   def index
     @forms = Form.includes :drafts
@@ -63,5 +63,11 @@ class FormsController < ApplicationController
 
   def find_form
     @form = Form.find(params.require :id)
+  end
+
+  def placeholder
+    @placeholder = User.new(email: session[:mail],
+                            first_name: session[:first_name],
+                            last_name: session[:last_name])
   end
 end

--- a/app/controllers/forms_controller.rb
+++ b/app/controllers/forms_controller.rb
@@ -6,7 +6,8 @@ class FormsController < ApplicationController
                                              :thank_you]
   # Since these actions are used to edit forms, maintain the form in session.
   before_action :find_form, only: [:show, :submit, :thank_you, :update]
-  before_action :placeholder, only: [:show, :meet_and_greet]
+  before_action :placeholder_from_shibboleth_attributes, only: [:show,
+    :meet_and_greet]
 
   def index
     @forms = Form.includes :drafts
@@ -65,9 +66,9 @@ class FormsController < ApplicationController
     @form = Form.find(params.require :id)
   end
 
-  def placeholder
-    @placeholder = User.new(email: session[:mail],
-                            first_name: session[:first_name],
-                            last_name: session[:last_name])
+  def placeholder_from_shibboleth_attributes
+    @placeholder = User.new(email: request.env['mail'],
+                            first_name: request.env['givenName'],
+                            last_name: request.env['surName'])
   end
 end

--- a/app/views/form_drafts/show.haml
+++ b/app/views/form_drafts/show.haml
@@ -14,7 +14,7 @@
     = fields_for :user do |u|
       .field
         .explanation 
-          This is the personal information we have on file for you.
+          This is the personal information we have for you.
           Please fill in any missing or incorrect information.
           The confirmation will be sent to this email address.
       - [:first_name, :last_name, :email].each do |field|

--- a/app/views/form_drafts/show.haml
+++ b/app/views/form_drafts/show.haml
@@ -13,13 +13,16 @@
   = form_tag controller: :forms, action: :submit, id: @draft.form.id do
     = fields_for :user do |u|
       .field
-        .heading Please complete the following personal information.
-        //.explanation You will be able to log in and review your submission.
+        .explanation 
+          This is the personal information we have on file for you.
+          Please fill in any missing or incorrect information.
+          The confirmation will be sent to this email address.
       - [:first_name, :last_name, :email].each do |field|
         .field
           .label= u.label field
-          = u.text_field field, size: 50, required: true,
-            value: @current_user.try(field)
+          = u.text_field field, size: 50,
+            value: @current_user.try(field) || @placeholder.try(field),
+            required: true
           %span.ast *
     = fields_for :responses do |r|
       - @draft.fields.each do |field|

--- a/app/views/form_drafts/show.haml
+++ b/app/views/form_drafts/show.haml
@@ -14,9 +14,9 @@
     = fields_for :user do |u|
       .field
         .explanation 
-          This is the personal information we have for you.
-          Please fill in any missing or incorrect information.
-          The confirmation will be sent to this email address.
+          This is the information we will use to confirm the
+          request. Please fill in any fields that have missing
+          or incorrect data.
       - [:first_name, :last_name, :email].each do |field|
         .field
           .label= u.label field

--- a/app/views/forms/show.haml
+++ b/app/views/forms/show.haml
@@ -11,7 +11,7 @@
     = fields_for :user do |u|
       .field
         .explanation 
-          This is the personal information we have on file for you.
+          This is the personal information we have for you.
           Please fill in any missing or incorrect information.
           The confirmation will be sent to this email address.
       - [:first_name, :last_name, :email].each do |field|

--- a/app/views/forms/show.haml
+++ b/app/views/forms/show.haml
@@ -10,13 +10,16 @@
     = hidden_field_tag :reply_to, @form.reply_to
     = fields_for :user do |u|
       .field
-        .heading Please complete the following personal information.
-        //.explanation You will be able to log in and review your submission.
+        .explanation 
+          This is the personal information we have on file for you.
+          Please fill in any missing or incorrect information.
+          The confirmation will be sent to this email address.
       - [:first_name, :last_name, :email].each do |field|
         .field
           .label= u.label field
-          = u.text_field field, size: 50, required: true,
-            value: @current_user.try(field)
+          = u.text_field field, size: 50,
+            value: @current_user.try(field) || @placeholder.try(field),
+            required: true
           %span.ast *
     = fields_for :responses do |r|
       - @form.fields.each do |field|

--- a/app/views/forms/show.haml
+++ b/app/views/forms/show.haml
@@ -11,9 +11,9 @@
     = fields_for :user do |u|
       .field
         .explanation 
-          This is the personal information we have for you.
-          Please fill in any missing or incorrect information.
-          The confirmation will be sent to this email address.
+          This is the information we will use to confirm this
+          request. Please fill in any fields that have missing
+          or incorrect data.
       - [:first_name, :last_name, :email].each do |field|
         .field
           .label= u.label field

--- a/coverage/.last_run.json
+++ b/coverage/.last_run.json
@@ -1,5 +1,5 @@
 {
   "result": {
-    "covered_percent": 99.64
+    "covered_percent": 100.0
   }
 }

--- a/spec/controllers/forms_controller_spec.rb
+++ b/spec/controllers/forms_controller_spec.rb
@@ -73,14 +73,14 @@ describe FormsController do
     context 'current user is nil' do
       it 'populates a placeholder variable with user attributes' do
         when_current_user_is nil
-        ['mail', 'givenName', 'surName'].each do |attribute|
-          request.env[attribute] = 'bananas'
-        end
+        request.env['mail'] = 'user@example.com'
+        request.env['givenName'] = 'bob'
+        request.env['surName'] = 'dole'
         submit
         new_user = assigns.fetch :placeholder
-        expect(new_user.first_name).to eql 'bananas'
-        expect(new_user.last_name).to eql 'bananas'
-        expect(new_user.email).to eql 'bananas'
+        expect(new_user.first_name).to eql 'bob'
+        expect(new_user.last_name).to eql 'dole'
+        expect(new_user.email).to eql 'user@example.com'
       end
     end
   end
@@ -110,14 +110,14 @@ describe FormsController do
     context 'current user is nil' do
       it 'populates a placeholder variable with user attributes' do
         when_current_user_is nil
-        ['mail', 'givenName', 'surName'].each do |attribute|
-          request.env[attribute] = 'bananas'
-        end
+        request.env['mail'] = 'user@example.com'
+        request.env['givenName'] = 'bob'
+        request.env['surName'] = 'dole'
         submit
         new_user = assigns.fetch :placeholder
-        expect(new_user.first_name).to eql 'bananas'
-        expect(new_user.last_name).to eql 'bananas'
-        expect(new_user.email).to eql 'bananas'
+        expect(new_user.first_name).to eql 'bob'
+        expect(new_user.last_name).to eql 'dole'
+        expect(new_user.email).to eql 'user@example.com'
       end
     end
   end
@@ -199,7 +199,7 @@ describe FormsController do
         it 'sets the current user based on spire' do
           session.delete('user_id')
           submit
-          expect(session['spire']).to eql User.first.spire
+          expect(session['spire']).to eql assigns[:current_user].spire
         end
       end
     end

--- a/spec/controllers/forms_controller_spec.rb
+++ b/spec/controllers/forms_controller_spec.rb
@@ -105,8 +105,8 @@ describe FormsController do
         @field.unique_prompt_name => @field.prompt
       }
       @user_attributes = { first_name: 'John',
-        last_name: 'Smith',
-        email: 'jsmith@example.com'
+                           last_name: 'Smith',
+                           email: 'jsmith@example.com'
       }
     end
     let :submit do
@@ -146,12 +146,12 @@ describe FormsController do
           it 'updates the current_user object' do
             [:email, :first_name, :last_name].each do |attribute|
               expect(@current_user.send(attribute))
-                                  .not_to eql @user_attributes[attribute]
+                .not_to eql @user_attributes[attribute]
             end
             submit
             [:email, :first_name, :last_name].each do |attribute|
               expect(@current_user.reload.send(attribute))
-                                  .to eql @user_attributes[attribute]
+                .to eql @user_attributes[attribute]
             end
           end
         end

--- a/spec/controllers/forms_controller_spec.rb
+++ b/spec/controllers/forms_controller_spec.rb
@@ -73,14 +73,14 @@ describe FormsController do
     context 'current user is nil' do
       it 'populates a placeholder variable with user attributes' do
         when_current_user_is nil
-        ['mail', 'first_name', 'last_name'].each do |attribute|
+        ['mail', 'givenName', 'surName'].each do |attribute|
           request.env[attribute] = 'bananas'
         end
         submit
         new_user = assigns.fetch :placeholder
-        expect(new_user.first_name).to eql "bananas"
-        expect(new_user.last_name).to eql "bananas"
-        expect(new_user.email).to eql "bananas"
+        expect(new_user.first_name).to eql 'bananas'
+        expect(new_user.last_name).to eql 'bananas'
+        expect(new_user.email).to eql 'bananas'
       end
     end
   end
@@ -110,14 +110,14 @@ describe FormsController do
     context 'current user is nil' do
       it 'populates a placeholder variable with user attributes' do
         when_current_user_is nil
-        ['mail', 'first_name', 'last_name'].each do |attribute|
+        ['mail', 'givenName', 'surName'].each do |attribute|
           request.env[attribute] = 'bananas'
         end
         submit
         new_user = assigns.fetch :placeholder
-        expect(new_user.first_name).to eql "bananas"
-        expect(new_user.last_name).to eql "bananas"
-        expect(new_user.email).to eql "bananas"
+        expect(new_user.first_name).to eql 'bananas'
+        expect(new_user.last_name).to eql 'bananas'
+        expect(new_user.email).to eql 'bananas'
       end
     end
   end

--- a/spec/controllers/forms_controller_spec.rb
+++ b/spec/controllers/forms_controller_spec.rb
@@ -77,7 +77,10 @@ describe FormsController do
           request.env[attribute] = 'bananas'
         end
         submit
-        expect(assigns.fetch :placeholder).not_to be_nil
+        new_user = assigns.fetch :placeholder
+        expect(new_user.first_name).to eql "bananas"
+        expect(new_user.last_name).to eql "bananas"
+        expect(new_user.email).to eql "bananas"
       end
     end
   end
@@ -111,7 +114,10 @@ describe FormsController do
           request.env[attribute] = 'bananas'
         end
         submit
-        expect(assigns.fetch :placeholder).not_to be_nil
+        new_user = assigns.fetch :placeholder
+        expect(new_user.first_name).to eql "bananas"
+        expect(new_user.last_name).to eql "bananas"
+        expect(new_user.email).to eql "bananas"
       end
     end
   end

--- a/spec/controllers/forms_controller_spec.rb
+++ b/spec/controllers/forms_controller_spec.rb
@@ -70,6 +70,16 @@ describe FormsController do
         end
       end
     end
+    context 'current user is nil' do
+      it 'populates a placeholder variable with user attributes' do
+        when_current_user_is nil
+        ['mail', 'first_name', 'last_name'].each do |attribute|
+          request.env[attribute] = 'bananas'
+        end
+        submit
+        expect(assigns.fetch :placeholder).not_to be_nil
+      end
+    end
   end
 
   describe 'GET #show' do
@@ -92,6 +102,16 @@ describe FormsController do
           submit
           expect(response).to render_template :show
         end
+      end
+    end
+    context 'current user is nil' do
+      it 'populates a placeholder variable with user attributes' do
+        when_current_user_is nil
+        ['mail', 'first_name', 'last_name'].each do |attribute|
+          request.env[attribute] = 'bananas'
+        end
+        submit
+        expect(assigns.fetch :placeholder).not_to be_nil
       end
     end
   end


### PR DESCRIPTION
![screen shot 2017-03-09 at 6 30 19 pm](https://cloud.githubusercontent.com/assets/9645316/23775402/8418af34-04f6-11e7-9057-3101c2ef37fe.png)

Now when you load the form, your first name, last name and email will be fetched from shibboleth and displayed on the page. You can change them and change them back later. Will reduce incorrect information being entered. Still not completely error-proof, but should help. 