### PR TITLE
Something about Rails 5.2 upgrade requires this.

### DIFF
--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -4,3 +4,4 @@ server 'af-transit-app3.admin.umass.edu',
         user: remote_user,
         ssh_options: { forward_agent: false }
 set :bundle_env_variables, { 'NOKOGIRI_USE_SYSTEM_LIBRARIES' => 1 }
+set :default_env, { 'SECRET_KEY_BASE' => 'NOT_A_REAL_SECRET_AND_THATS_OK' }


### PR DESCRIPTION
Not sure what, but rake tasks won't run without a `SECRET_KEY_BASE` now. This is the same fix that we're [using on stop-project](https://github.com/umts/stop-project/blob/2afca41f28fca483fb4552bd5865516b3b8e3841/config/deploy/production.rb#L7).