### PR TITLE
Enforce ruby version while bundling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,19 @@
 dist: trusty
 language: ruby
-rvm: 2.4.1
-env: 
+env:
   - 'CODECLIMATE_REPO_TOKEN=1db52f66a36ea0f99a5fdfccabaeb065503615fef8dbf49087f9a1e8692af3b2'
 addons:
   chrome: stable
+before_install:
+  - gem update --system
+  - gem install bundler
 install:
   - bundle install --jobs=3 --retry=3 --deployment
   - npm i -g yarn
   - yarn
-before_script: 
+before_script:
   - cp config/database.yml.example config/database.yml
-  - mysql -e 'create database ftforms_test'
-script: 
+script:
   - bundle exec rake db:reset 
   - bundle exec rspec
   - bundle exec codeclimate-test-reporter

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 source 'https://rubygems.org'
+ruby IO.read(File.expand_path('.ruby-version', __dir__)).strip
 
 gem 'bootstrap', '~> 4.3.1'
 gem 'coffee-rails'


### PR DESCRIPTION
Turns out we were already "on" 2.6 in this app, but not enforced in production.

Addresses umts/transit-it#922