### PR TITLE
Travis's Chrome installer no longer works in Trusty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: trusty
+dist: bionic
 language: ruby
 env:
   - 'CODECLIMATE_REPO_TOKEN=1db52f66a36ea0f99a5fdfccabaeb065503615fef8dbf49087f9a1e8692af3b2'

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ env:
   - 'CODECLIMATE_REPO_TOKEN=1db52f66a36ea0f99a5fdfccabaeb065503615fef8dbf49087f9a1e8692af3b2'
 addons:
   chrome: stable
+services:
+  - mysql
 install:
   - bundle install --jobs=3 --retry=3 --deployment
   - npm i -g yarn


### PR DESCRIPTION
This is caused by the version of dpkg that comes with Trusty not supporting the package format that Chrome releases. Trusty is EOL anyways, though.