### PR TITLE
Remove capistrano-yarn

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-%w[setup deploy scm/git pending bundler rails passenger yarn]
+%w[setup deploy scm/git pending bundler rails passenger]
   .each { |r| require "capistrano/#{r}" }
 
 install_plugin Capistrano::SCM::Git

--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,6 @@ group :development do
   gem 'capistrano-passenger', require: false
   gem 'capistrano-pending', require: false
   gem 'capistrano-rails', require: false
-  gem 'capistrano-yarn', require: false
   gem 'listen'
   gem 'rb-readline', require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -89,8 +89,6 @@ GEM
     capistrano-rails (1.6.1)
       capistrano (~> 3.1)
       capistrano-bundler (>= 1.1, < 3)
-    capistrano-yarn (2.0.2)
-      capistrano (~> 3.0)
     capybara (3.34.0)
       addressable
       mini_mime (>= 0.1.3)
@@ -349,7 +347,6 @@ DEPENDENCIES
   capistrano-passenger
   capistrano-pending
   capistrano-rails
-  capistrano-yarn
   capybara
   codeclimate-test-reporter (~> 1.0)
   coffee-rails


### PR DESCRIPTION
The rails asset:precompile step also runs yarn (on Rails versions that have official yarn support).