### PR TITLE
Fix `new_spire` method in dev

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -36,6 +36,6 @@ class SessionsController < ApplicationController
   end
 
   def new_spire
-    (User.pluck(:spire).map(&:to_i).last + 1).to_s.rjust 8, '0'
+    format('%08d@umass.edu', User.maximum(:spire).to_i + 1)
   end
 end


### PR DESCRIPTION
1. Didn't work if there were no users in the database, which raised an exception.
2. Spire IDs in this app have the "@umass.edu" at the end (`fcIdNumber`)