### PR TITLE
Raise email delivery errors

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -76,7 +76,7 @@ Rails.application.configure do
   }
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
-  config.action_mailer.raise_delivery_errors = false
+  config.action_mailer.raise_delivery_errors = true
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).


### PR DESCRIPTION
This may lead to _false_ `500`s -- the most common case we've run into is someone typoing their @umass.edu email address. But better that just throwing out the submission, IMO

Closes #176